### PR TITLE
Experiments ownership

### DIFF
--- a/src/main/java/eu/hbp/mip/controllers/ExperimentApi.java
+++ b/src/main/java/eu/hbp/mip/controllers/ExperimentApi.java
@@ -104,7 +104,6 @@ public class ExperimentApi {
         }
 
         if (!experiment.isShared() && experiment.getCreatedBy().getUsername().compareTo(userInfo.getUser().getUsername()) != 0) {
-
             return new ResponseEntity<>("You have no access to the experiment", HttpStatus.UNAUTHORIZED);
         }
 

--- a/src/main/java/eu/hbp/mip/controllers/ExperimentApi.java
+++ b/src/main/java/eu/hbp/mip/controllers/ExperimentApi.java
@@ -100,11 +100,13 @@ public class ExperimentApi {
         experiment = experimentRepository.findOne(experimentUuid);
 
         if (experiment == null) {
+            UserActionLogging.LogUserAction(userInfo.getUser().getUsername(), "Get Experiment", "Experiment Not found.");
             return new ResponseEntity<>("Not found", HttpStatus.NOT_FOUND);
         }
 
         if (!experiment.isShared() && experiment.getCreatedBy().getUsername().compareTo(userInfo.getUser().getUsername()) != 0) {
-            return new ResponseEntity<>("You have no access to the experiment", HttpStatus.UNAUTHORIZED);
+            UserActionLogging.LogUserAction(userInfo.getUser().getUsername(), "Get Experiment", "Accessing Experiment is unauthorized.");
+            return new ResponseEntity<>("You don't have access to the experiment.", HttpStatus.UNAUTHORIZED);
         }
 
         UserActionLogging.LogUserAction(userInfo.getUser().getUsername(), "Get an experiment ", " uuid : " + uuid);
@@ -118,7 +120,7 @@ public class ExperimentApi {
     public ResponseEntity<String> runExperiment(Authentication authentication, @RequestBody ExperimentExecutionDTO experimentExecutionDTO) {
         UserActionLogging.LogUserAction(userInfo.getUser().getUsername(), "Run algorithm", "Running the algorithm...");
 
-        if(authenticationIsEnabled) {
+        if (authenticationIsEnabled) {
             // Getting the dataset from the experiment parameters
             String experimentDatasets = null;
             for (ExperimentExecutionDTO.AlgorithmExecutionDTO.AlgorithmExecutionParamDTO parameter : experimentExecutionDTO.getAlgorithms().get(0).getParameters()) {
@@ -136,7 +138,7 @@ public class ExperimentApi {
             }
 
             // --- Validating proper access rights on the datasets  ---
-            if (!ClaimUtils.userHasDatasetsAuthorization(userInfo.getUser().getUsername(), authentication.getAuthorities(), experimentDatasets)){
+            if (!ClaimUtils.userHasDatasetsAuthorization(userInfo.getUser().getUsername(), authentication.getAuthorities(), experimentDatasets)) {
                 return ResponseEntity.badRequest().body("You are not authorized to use these datasets.");
             }
         }

--- a/src/main/java/eu/hbp/mip/controllers/ExperimentApi.java
+++ b/src/main/java/eu/hbp/mip/controllers/ExperimentApi.java
@@ -103,6 +103,11 @@ public class ExperimentApi {
             return new ResponseEntity<>("Not found", HttpStatus.NOT_FOUND);
         }
 
+        if (!experiment.isShared() && experiment.getCreatedBy().getUsername().compareTo(userInfo.getUser().getUsername()) != 0) {
+
+            return new ResponseEntity<>("You have no access to the experiment", HttpStatus.UNAUTHORIZED);
+        }
+
         UserActionLogging.LogUserAction(userInfo.getUser().getUsername(), "Get an experiment ", " uuid : " + uuid);
 
         return new ResponseEntity<>(gsonOnlyExposed.toJson(experiment.jsonify()), HttpStatus.OK);


### PR DESCRIPTION
Updated the method getExperiment so an experiment can be accessed in two cases: 
1. If it is shared to everyone
 2. If it is not shared only the owner can access it.

If none of the above is the case it will return a UNAUTHORIZED Http Status.
