### PR TITLE
Dev/mip 581/provide experiment UUID to mipengine request

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
         <jquery.version>3.0.0</jquery.version>
         <bootstrap.version>3.3.7</bootstrap.version>
         <webjars-locator.version>0.36</webjars-locator.version>
-        <h2.version>1.4.192</h2.version>
-        <postgresql.version>42.2.1</postgresql.version>
+        <h2.version>2.1.210</h2.version>
+        <postgresql.version>42.3.3</postgresql.version>
         <gson.version>2.7</gson.version>
         <slugify.version>2.1.5</slugify.version>
         <maven-resources-plugin.version>3.0.1</maven-resources-plugin.version>
@@ -43,11 +43,11 @@
         <commons-dbcp.version>2.7.0</commons-dbcp.version>
         <flyway-core.version>4.2.0</flyway-core.version>
         <hibernate-jpa-2.1-api.version>1.0.0.Final</hibernate-jpa-2.1-api.version>
-        <hibernate.version>5.4.10.Final</hibernate.version>
+        <hibernate.version>5.4.24.Final</hibernate.version>
         <hibernate-validator.version>6.1.0.Final</hibernate-validator.version>
         <aspectjweaver.version>1.8.9</aspectjweaver.version>
         <javax-inject.version>1</javax-inject.version>
-        <protobuf-java.version>3.1.0</protobuf-java.version>
+        <protobuf-java.version>3.16.1</protobuf-java.version>
     </properties>
 
     <repositories>

--- a/src/main/java/eu/hbp/mip/controllers/AlgorithmsAPI.java
+++ b/src/main/java/eu/hbp/mip/controllers/AlgorithmsAPI.java
@@ -150,7 +150,6 @@ public class AlgorithmsAPI {
         try {
             StringBuilder response = new StringBuilder();
             HTTPUtil.sendGet(mipengineAlgorithmsUrl, response);
-            logger.LogUserAction(response.toString());
             mipEngineAlgorithms = gson.fromJson(
                     response.toString(),
                     new TypeToken<ArrayList<MIPEngineAlgorithmDTO>>() {

--- a/src/main/java/eu/hbp/mip/models/DTOs/ExaremeAlgorithmDTO.java
+++ b/src/main/java/eu/hbp/mip/models/DTOs/ExaremeAlgorithmDTO.java
@@ -4,7 +4,8 @@ import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 @AllArgsConstructor
@@ -25,26 +26,26 @@ public class ExaremeAlgorithmDTO {
     @SerializedName("parameters")
     private List<ExaremeAlgorithmRequestParamDTO> parameters;
 
-    public ExaremeAlgorithmDTO()
-    {
+    public ExaremeAlgorithmDTO() {
 
     }
 
-    public ExaremeAlgorithmDTO(MIPEngineAlgorithmDTO mipEngineAlgorithm )
-    {
+    public ExaremeAlgorithmDTO(MIPEngineAlgorithmDTO mipEngineAlgorithm) {
         this.name = mipEngineAlgorithm.getName().toUpperCase();
         this.label = mipEngineAlgorithm.getLabel();
         this.desc = mipEngineAlgorithm.getDesc();
         this.type = "mipengine";
         List<ExaremeAlgorithmRequestParamDTO> parameters = new ArrayList<>();
-        if (mipEngineAlgorithm.getInputdata().getY().isPresent()){
+        if (mipEngineAlgorithm.getInputdata().getY().isPresent()) {
             parameters.add(new ExaremeAlgorithmRequestParamDTO("y", mipEngineAlgorithm.getInputdata().getY().get()));
         }
-        parameters.add(new ExaremeAlgorithmRequestParamDTO("x", mipEngineAlgorithm.getInputdata().getX()));
-        parameters.add(new ExaremeAlgorithmRequestParamDTO("pathology", mipEngineAlgorithm.getInputdata().getPathology()));
+        if (mipEngineAlgorithm.getInputdata().getX().isPresent()) {
+            parameters.add(new ExaremeAlgorithmRequestParamDTO("x", mipEngineAlgorithm.getInputdata().getX().get()));
+        }
+        parameters.add(new ExaremeAlgorithmRequestParamDTO("pathology", mipEngineAlgorithm.getInputdata().getData_model()));
         parameters.add(new ExaremeAlgorithmRequestParamDTO("dataset", mipEngineAlgorithm.getInputdata().getDatasets()));
         parameters.add(new ExaremeAlgorithmRequestParamDTO("filter", mipEngineAlgorithm.getInputdata().getFilter()));
-        if (mipEngineAlgorithm.getParameters().isPresent()){
+        if (mipEngineAlgorithm.getParameters().isPresent()) {
             mipEngineAlgorithm.getParameters().get().forEach((name, parameterDTO) -> {
                 ExaremeAlgorithmRequestParamDTO parameter = new ExaremeAlgorithmRequestParamDTO(name, parameterDTO);
                 parameters.add(parameter);
@@ -52,10 +53,10 @@ public class ExaremeAlgorithmDTO {
         }
         this.setParameters(parameters);
     }
+
     @Data
     @AllArgsConstructor
-    static class Rule
-    {
+    static class Rule {
         @SerializedName("id")
         private String id;
 

--- a/src/main/java/eu/hbp/mip/models/DTOs/MIPEngineAlgorithmDTO.java
+++ b/src/main/java/eu/hbp/mip/models/DTOs/MIPEngineAlgorithmDTO.java
@@ -78,8 +78,8 @@ public class MIPEngineAlgorithmDTO {
         @SerializedName("y")
         private MIPEngineAlgorithmInputDataDetailDTO y;
 
-        @SerializedName("pathology")
-        private MIPEngineAlgorithmInputDataDetailDTO pathology;
+        @SerializedName("data_model")
+        private MIPEngineAlgorithmInputDataDetailDTO data_model;
 
         @SerializedName("datasets")
         private MIPEngineAlgorithmInputDataDetailDTO datasets;
@@ -89,6 +89,10 @@ public class MIPEngineAlgorithmDTO {
 
         public Optional<MIPEngineAlgorithmInputDataDetailDTO> getY() {
             return Optional.ofNullable(y);
+        }
+
+        public Optional<MIPEngineAlgorithmInputDataDetailDTO> getX() {
+            return Optional.ofNullable(x);
         }
     }
 

--- a/src/main/java/eu/hbp/mip/models/DTOs/MIPEngineAlgorithmRequestDTO.java
+++ b/src/main/java/eu/hbp/mip/models/DTOs/MIPEngineAlgorithmRequestDTO.java
@@ -17,8 +17,7 @@ public class MIPEngineAlgorithmRequestDTO {
     @SerializedName("parameters")
     private HashMap<String, Object> parameters;
 
-    public MIPEngineAlgorithmRequestDTO(UUID experimentUUID, List<ExaremeAlgorithmRequestParamDTO> exaremeAlgorithmRequestParamDTOs)
-    {
+    public MIPEngineAlgorithmRequestDTO(UUID experimentUUID, List<ExaremeAlgorithmRequestParamDTO> exaremeAlgorithmRequestParamDTOs) {
         this.request_id = experimentUUID.toString();
         MIPEngineAlgorithmRequestDTO.InputData inputData = new MIPEngineAlgorithmRequestDTO.InputData();
         HashMap<String, Object> mipEngineParameters = new HashMap<>();
@@ -50,14 +49,61 @@ public class MIPEngineAlgorithmRequestDTO {
                         rules.add(JsonConverters.convertJsonStringToObject(parameter.getValue(), MIPEngineAlgorithmRequestDTO.Filter.class));
                     break;
                 default:
-                    mipEngineParameters.put(parameter.getName(), Arrays.asList(parameter.getValue().split(",")));
-                    break;
+                    mipEngineParameters.put(parameter.getName(), convertStringToMultipleValues(parameter.getValue()));
             }
         });
         MIPEngineAlgorithmRequestDTO.Filter filter = new MIPEngineAlgorithmRequestDTO.Filter("AND", rules);
         inputData.setFilters(filter);
         this.inputdata = inputData;
         this.parameters = mipEngineParameters;
+    }
+
+    private static Object convertStringToMultipleValues(String str) {
+        String[] stringValues = str.split(",");
+        if (stringValues.length == 0)
+            return "";
+
+        if (stringValues.length == 1)
+            return convertStringToNumeric(stringValues[0]);
+
+        List<Object> values = new ArrayList<>();
+        for (String value : stringValues) {
+            values.add(convertStringToNumeric(value));
+        }
+        return values;
+    }
+
+    private static Object convertStringToNumeric(String str) {
+        if (isInteger(str))
+            return Integer.parseInt(str);
+        else if (isFloat(str))
+            return Double.parseDouble(str);
+        else
+            return str;
+    }
+
+    private static boolean isFloat(String strNum) {
+        if (strNum == null) {
+            return false;
+        }
+        try {
+            double d = Double.parseDouble(strNum);
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean isInteger(String strNum) {
+        if (strNum == null) {
+            return false;
+        }
+        try {
+            double d = Integer.parseInt(strNum);
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+        return true;
     }
 
 
@@ -74,15 +120,15 @@ public class MIPEngineAlgorithmRequestDTO {
         private List<String> x;
         @SerializedName("y")
         private List<String> y;
-        public InputData(){
+
+        public InputData() {
 
         }
     }
 
     @Data
     @AllArgsConstructor
-    public static class Filter
-    {
+    public static class Filter {
         @SerializedName("condition")
         private String condition;
 

--- a/src/main/java/eu/hbp/mip/models/DTOs/MIPEngineAlgorithmRequestDTO.java
+++ b/src/main/java/eu/hbp/mip/models/DTOs/MIPEngineAlgorithmRequestDTO.java
@@ -5,21 +5,21 @@ import eu.hbp.mip.utils.JsonConverters;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 
 @Data
 @AllArgsConstructor
 public class MIPEngineAlgorithmRequestDTO {
+    @SerializedName("request_id")
+    private String request_id;
     @SerializedName("inputdata")
     private InputData inputdata;
     @SerializedName("parameters")
     private HashMap<String, Object> parameters;
 
-    public MIPEngineAlgorithmRequestDTO(List<ExaremeAlgorithmRequestParamDTO> exaremeAlgorithmRequestParamDTOs)
+    public MIPEngineAlgorithmRequestDTO(UUID experimentUUID, List<ExaremeAlgorithmRequestParamDTO> exaremeAlgorithmRequestParamDTOs)
     {
+        this.request_id = experimentUUID.toString();
         MIPEngineAlgorithmRequestDTO.InputData inputData = new MIPEngineAlgorithmRequestDTO.InputData();
         HashMap<String, Object> mipEngineParameters = new HashMap<>();
 
@@ -43,7 +43,7 @@ public class MIPEngineAlgorithmRequestDTO {
                     inputData.setDatasets(datasets);
                     break;
                 case "pathology":
-                    inputData.setPathology(parameter.getValue());
+                    inputData.setData_model(parameter.getValue());
                     break;
                 case "filter":
                     if (!parameter.getValue().equals(""))
@@ -64,8 +64,8 @@ public class MIPEngineAlgorithmRequestDTO {
     @Data
     @AllArgsConstructor
     public static class InputData {
-        @SerializedName("pathology")
-        private String pathology;
+        @SerializedName("data_model")
+        private String data_model;
         @SerializedName("datasets")
         private List<String> datasets;
         @SerializedName("filters")

--- a/src/main/java/eu/hbp/mip/repositories/ExperimentRepository.java
+++ b/src/main/java/eu/hbp/mip/repositories/ExperimentRepository.java
@@ -73,10 +73,6 @@ public interface ExperimentRepository extends CrudRepository<ExperimentDAO, UUID
             logger.LogUserAction("Attempted to save changes to database but an error ocurred  : " + e.getMessage() + ".");
             throw new InternalServerError(e.getMessage());
         }
-
-        logger.LogUserAction(" id : " + experimentDAO.getUuid());
-        logger.LogUserAction(" algorithm : " + experimentDAO.getAlgorithm());
-        logger.LogUserAction(" name : " + experimentDAO.getName());
         return experimentDAO;
     }
 

--- a/src/main/java/eu/hbp/mip/services/ExperimentService.java
+++ b/src/main/java/eu/hbp/mip/services/ExperimentService.java
@@ -403,6 +403,7 @@ public class ExperimentService {
         logger.LogUserAction("Running the algorithm...");
 
         ExperimentDAO experimentDAO = experimentRepository.createExperimentInTheDatabase(experimentDTO, activeUserService.getActiveUser(), logger);
+        experimentDTO.setUuid(experimentDAO.getUuid());
         logger.LogUserAction("Created experiment with uuid :" + experimentDAO.getUuid());
 
         logger.LogUserAction("Starting execution in thread");
@@ -422,9 +423,8 @@ public class ExperimentService {
                 experimentDAO.setStatus((exaremeAlgorithmResultDTO.getCode() >= 400)
                         ? ExperimentDAO.Status.error : ExperimentDAO.Status.success);
             } catch (Exception e) {
-                logger.LogUserAction("There was an exception: " + e.getMessage());
-
                 experimentDAO.setStatus(ExperimentDAO.Status.error);
+                throw e;
             }
 
             experimentRepository.finishExperiment(experimentDAO, logger);
@@ -499,7 +499,7 @@ public class ExperimentService {
 
         String algorithmEndpoint = mipengineAlgorithmsUrl + "/" + algorithmName.toLowerCase();
         MIPEngineAlgorithmRequestDTO mipEngineAlgorithmRequestDTO =
-                new MIPEngineAlgorithmRequestDTO(experimentDTO.getAlgorithm().getParameters());
+                new MIPEngineAlgorithmRequestDTO(experimentDTO.getUuid(), experimentDTO.getAlgorithm().getParameters());
         String algorithmBody = JsonConverters.convertObjectToJsonString(mipEngineAlgorithmRequestDTO);
         logger.LogUserAction("MIP-Engine algorithm execution. Endpoint: " + algorithmEndpoint);
         logger.LogUserAction("MIP-Engine algorithm execution. Body: " + algorithmBody);

--- a/src/main/java/eu/hbp/mip/utils/ControllerExceptionHandler.java
+++ b/src/main/java/eu/hbp/mip/utils/ControllerExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+import java.util.Arrays;
 import java.util.Date;
 
 @ControllerAdvice
@@ -15,7 +16,6 @@ public class ControllerExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(ExperimentNotFoundException.class)
     public ResponseEntity<Object> handleExperimentNotFoundException(ExperimentNotFoundException ex, WebRequest request) {
-
         ErrorMessage message = new ErrorMessage(
                 HttpStatus.NOT_FOUND.value(),
                 new Date(),
@@ -27,7 +27,6 @@ public class ControllerExceptionHandler extends ResponseEntityExceptionHandler {
     
     @ExceptionHandler(BadRequestException.class)
     public ResponseEntity<Object> handleBadRequestException(BadRequestException ex, WebRequest request) {
-
         ErrorMessage message = new ErrorMessage(
                 HttpStatus.BAD_REQUEST.value(),
                 new Date(),
@@ -39,7 +38,6 @@ public class ControllerExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(UnauthorizedException.class)
     public ResponseEntity<Object> handleUnauthorizedException(UnauthorizedException ex, WebRequest request) {
-
         ErrorMessage message = new ErrorMessage(
                 HttpStatus.UNAUTHORIZED.value(),
                 new Date(),
@@ -49,13 +47,12 @@ public class ControllerExceptionHandler extends ResponseEntityExceptionHandler {
         return new ResponseEntity<>(message, HttpStatus.UNAUTHORIZED);
     }
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public Object handleIllegalArgumentException(IllegalArgumentException ex, WebRequest request) {
-        return null;
-    }
-
     @ExceptionHandler(InternalServerError.class)
     public ResponseEntity<ErrorMessage> handleInternalServerError(InternalServerError er, WebRequest request) {
+        logger.error("An unexpected exception occurred: " + er.getClass() +
+                "\nMessage: " + er.getMessage() +
+                "\nStacktrace: " + Arrays.toString(er.getStackTrace()).replaceAll(", ", "\n")
+        );
         ErrorMessage message = new ErrorMessage(
                 HttpStatus.INTERNAL_SERVER_ERROR.value(),
                 new Date(),
@@ -78,6 +75,10 @@ public class ControllerExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorMessage> globalExceptionHandler(Exception ex, WebRequest request) {
+        logger.error("An unexpected exception occurred: " + ex.getClass() +
+                "\nMessage: " + ex.getMessage() +
+                "\nStacktrace: " + Arrays.toString(ex.getStackTrace()).replaceAll(", ", "\n")
+        );
         ErrorMessage message = new ErrorMessage(
                 HttpStatus.INTERNAL_SERVER_ERROR.value(),
                 new Date(),


### PR DESCRIPTION
Changelog:
  - UUID provided in MIP-Engine algorithm request as 'request_id'.
  - Updated some dependencies.
  - When an exception happens, we log the exeption and the stacktrace.
  - Integration with MIP-Engine 0.7.0
    - X and Y parameters are now both optional.
    - MIP-Engine 'pathology' parameter changed to 'data_model'.
    - MIP-Engine parameter values converted to Integer/Double when possible.