### PR TITLE
On the redirect-uri url is now read by an env var .Env.EXTERNAL_IP.

### DIFF
--- a/config/application.tmpl
+++ b/config/application.tmpl
@@ -46,10 +46,10 @@ spring:
             client-secret: {{ .Env.KEYCLOAK_CLIENT_SECRET }}
             provider: keycloak
             scope: openid
-            redirect-uri: http://172.17.0.1/${server.servlet.contextPath}/login/oauth2/code/{{ .Env.KEYCLOAK_REALM }}
+            redirect-uri: http://{{ .Env.EXTERNAL_IP }}/${server.servlet.contextPath}/login/oauth2/code/{{ .Env.KEYCLOAK_REALM }}
         provider:
           keycloak:
-            issuer-uri: http://172.17.0.1/auth/realms/{{ .Env.KEYCLOAK_REALM }}
+            issuer-uri: http://{{ .Env.KEYCLOAK_URL }}/auth/realms/{{ .Env.KEYCLOAK_REALM }}
             user-name-attribute: preferred_username
 
 


### PR DESCRIPTION
On the issuer-uri url is now read by an env var .Env.KEYCLOAK_URL.